### PR TITLE
Update readme file with resize options. Fix startedAt undefined error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@
       adapter: require('skipper-s3-resize'),
       key: <YOUR_S3_KEY>,
       secret: <YOUR_S3_SECRET>,
-      bucket: <YOUR_S3_BUCKET>
+      bucket: <YOUR_S3_BUCKET>,
+      resize: {
+        width: <WIDTH>,
+        height: <HEIGHT>,
+        options: <GRAPHICMAGICK_OPTIONS>
+      }
     }, function(err, uploadedFiles) {
       if(err) return res.serverError(err);
         res.ok();

--- a/index.js
+++ b/index.js
@@ -217,9 +217,13 @@ module.exports = function SkipperS3 (globalOpts) {
     // into this receiver.  (filename === `__newFile.filename`).
     receiver__._write = function onFile(__newFile, encoding, next) {
 
+      var startedAt = new Date();
+      var width = options.resize.width || 200;
+      var height = options.resize.height || 200;
+      var gmOptions = options.resize.options || '';
       // Allow `tmpdir` for knox-mpu to be passed in, or default
       // to `.tmp/s3-upload-part-queue`
-      gm(__newFile).resize(200, 200, "!").stream(function (err, stdout, stderr) {
+      gm(__newFile).resize(width, height, gmOptions).stream(function (err, stdout, stderr) {
         if (err) return next(err);
 
         options.tmpdir = options.tmpdir || path.resolve(process.cwd(), '.tmp/s3-upload-part-queue');


### PR DESCRIPTION
1. Fix startedAt undefined error.
2. Remove hardcoded resize options and update Readmefile.
